### PR TITLE
BUILD-6194 Support million collect testing in Evergreen

### DIFF
--- a/largescale/run-million-collection-test.sh
+++ b/largescale/run-million-collection-test.sh
@@ -60,7 +60,7 @@ function merge_wiredtiger_develop() {
 }
 
 function build_mongod() { 
-	pip install -r buildscripts/requirements.txt
+	sudo pip install -r buildscripts/requirements.txt
 	python buildscripts/scons.py CC=/opt/mongodbtoolchain/v2/bin/gcc CXX=/opt/mongodbtoolchain/v2/bin/g++ ${PERF_MAKE_FLAGS} mongod || exit $?
 }
 

--- a/largescale/run-million-collection-test.sh
+++ b/largescale/run-million-collection-test.sh
@@ -42,7 +42,7 @@ function prepare_test_env() {
 
 function merge_wiredtiger_develop() { 
 	(cd src/third_party
-	curl -OL https://api.github.com/repos/wiredtiger/wiredtiger/tarball/develop
+	curl -L https://api.github.com/repos/wiredtiger/wiredtiger/tarball/develop -o wiredtiger-wiredtiger-develop.tar.gz
 	tarball=$(echo wiredtiger-wiredtiger-*.tar.gz)
 	test -f "${tarball}"
 	mkdir -p wiredtiger

--- a/largescale/run-million-collection-test.sh
+++ b/largescale/run-million-collection-test.sh
@@ -3,7 +3,7 @@
 # A script to prepare test environment and execute million collections testing.
 # 
 
-set -eux
+set -ux
 
 MONGO_REPO="https://github.com/mongodb/mongo"
 MONGO_TESTS_REPO="https://github.com/wiredtiger/mongo-tests"

--- a/largescale/run-million-collection-test.sh
+++ b/largescale/run-million-collection-test.sh
@@ -42,7 +42,7 @@ function prepare_test_env() {
 
 function merge_wiredtiger_develop() { 
 	(cd src/third_party
-	curl -OJL https://api.github.com/repos/wiredtiger/wiredtiger/tarball/develop
+	curl -OL https://api.github.com/repos/wiredtiger/wiredtiger/tarball/develop
 	tarball=$(echo wiredtiger-wiredtiger-*.tar.gz)
 	test -f "${tarball}"
 	mkdir -p wiredtiger

--- a/largescale/run-million-collection-test.sh
+++ b/largescale/run-million-collection-test.sh
@@ -23,10 +23,15 @@ function prepare_test_env() {
 
 	# Clone other repos inside the test directory
 	cd ${TEST_DIR}
-	git clone ${MONGO_TESTS_REPO} || exit $?
-	git clone -b ${POCDRIVER_BRANCH} ${POCDRIVER_REPO} || exit $?
+	git clone -b million-collect-test-evg ${MONGO_TESTS_REPO} || exit $?
+
+	# Copy POCDriver.jar over from mongo-tests local repo
+	mkdir -p POCDriver/bin
+	cp mongo-tests/largescale/POCDriver.jar POCDriver/bin/
+
+	#git clone -b ${POCDRIVER_BRANCH} ${POCDRIVER_REPO} || exit $?
 	# Build from the POCDriver repo
-	( cd POCDriver && mvn clean package )
+	#( cd POCDriver && mvn clean package )
 
 	# Setup directory to record test output
 	if [ -d "results" ]; then

--- a/largescale/run-million-collection-test.sh
+++ b/largescale/run-million-collection-test.sh
@@ -61,7 +61,8 @@ function merge_wiredtiger_develop() {
 
 function build_mongod() { 
 	sudo pip install -r buildscripts/requirements.txt
-	python buildscripts/scons.py CC=/opt/mongodbtoolchain/v2/bin/gcc CXX=/opt/mongodbtoolchain/v2/bin/g++ ${PERF_MAKE_FLAGS} mongod || exit $?
+	PYTHON="/opt/mongodbtoolchain/v2/bin/python"
+	${PYTHON} buildscripts/scons.py CC=/opt/mongodbtoolchain/v2/bin/gcc CXX=/opt/mongodbtoolchain/v2/bin/g++ ${PERF_MAKE_FLAGS} mongod || exit $?
 }
 
 function start_mongod(){

--- a/largescale/run-million-collection-test.sh
+++ b/largescale/run-million-collection-test.sh
@@ -60,6 +60,7 @@ function merge_wiredtiger_develop() {
 }
 
 function build_mongod() { 
+	pip install -r buildscripts/requirements.txt
 	python buildscripts/scons.py CC=/opt/mongodbtoolchain/v2/bin/gcc CXX=/opt/mongodbtoolchain/v2/bin/g++ ${PERF_MAKE_FLAGS} mongod || exit $?
 }
 


### PR DESCRIPTION
Changes in this pull request is to provide a working wrapper script that can be called in Evergreen `WiredTiger` project to run the million collection testing on `rhel62-large` build host. 

Some of the utility packages (e.g. curl, python) on RHEL 6 system are of relatively lower version , which did not work out-of-the-box and need workarounds to get them working on the `rhel62-large` build host. 

The evergreen yaml change will be covered by the linked WT ticket. 