### PR TITLE
BUILD-7121 Change scons option for million collection testing

### DIFF
--- a/largescale/run-million-collection-test.sh
+++ b/largescale/run-million-collection-test.sh
@@ -66,7 +66,7 @@ function merge_wiredtiger_develop() {
 }
 
 function build_mongod() { 
-	${PYTHON} buildscripts/scons.py CC=/opt/mongodbtoolchain/v2/bin/gcc CXX=/opt/mongodbtoolchain/v2/bin/g++ ${PERF_MAKE_FLAGS} mongod || exit $?
+	${PYTHON} buildscripts/scons.py --variables-files=etc/scons/mongodbtoolchain_stable_gcc.vars ${PERF_MAKE_FLAGS} mongod || exit $?
 }
 
 function start_mongod(){


### PR DESCRIPTION
With recent vendoring of Zstandard 1.3.7 into mongo repo, the million collection testing failed to compile with existing 'CC and CXX' scons invocation settings. Consulted server tools team and got suggestion of using `--variables-files=etc/scons/mongodbtoolchain_stable_gcc.vars`. Million collection testing was running fine on both Evergreen and Jenkins with this change. 