### PR TITLE
WT-7490 Fix the use of -j option with a higher value than available cpus on Icecream

### DIFF
--- a/largescale/run-million-collection-test.sh
+++ b/largescale/run-million-collection-test.sh
@@ -10,7 +10,7 @@ MONGO_TESTS_REPO="https://github.com/wiredtiger/mongo-tests"
 POCDRIVER_BRANCH="mongodb-million-collections"
 TEST_DIR="mongo-million-collection-test"
 BIN_DIR="build/install/bin/"
-PERF_MAKE_FLAGS="-j 16"
+PERF_MAKE_FLAGS="-j $(nproc --all)"
 
 # Use mongodbtoolchain Python binary when possible
 if [ -f /opt/mongodbtoolchain/v3/bin/python3 ]; then 

--- a/largescale/run-million-collection-test.sh
+++ b/largescale/run-million-collection-test.sh
@@ -10,7 +10,7 @@ MONGO_TESTS_REPO="https://github.com/wiredtiger/mongo-tests"
 POCDRIVER_BRANCH="mongodb-million-collections"
 TEST_DIR="mongo-million-collection-test"
 BIN_DIR="build/install/bin/"
-PERF_MAKE_FLAGS="-j 20"
+PERF_MAKE_FLAGS="-j 16"
 
 # Use mongodbtoolchain Python binary when possible
 if [ -f /opt/mongodbtoolchain/v3/bin/python3 ]; then 


### PR DESCRIPTION
This ticket involves the error we have been seen in million-collection-test build variant we are seeing. This fix includes lowering the number of threads to be compatible with the machines.